### PR TITLE
feature body parser warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Various example apps
+- Warning message (`console.warn`) if `@Body` is used without `body-parser` package.
 
 ### Fixed
 - `npm test` command not working.

--- a/controllers/ControllerDecorator.ts
+++ b/controllers/ControllerDecorator.ts
@@ -17,10 +17,18 @@ import {ErrorHandlerManager, ERRORHANDLER_KEY, DEFAULT_ERROR_HANDLER} from '../e
 import httpStatus = require('http-status');
 
 let controllers: ControllerRegistration[] = [],
-    definedRoutes = [];
+    definedRoutes = [],
+    bodyParserInstalled = false;
 
 const PRIMITIVE_TYPES = [Object, String, Array, Number, Boolean],
     NON_JSON_TYPES = [String, Number, Boolean];
+
+try {
+    require('body-parser');
+    bodyParserInstalled = true;
+} catch (e) {
+    bodyParserInstalled = false;
+}
 
 class ControllerRegistration {
     constructor(public controller: any, public prefix?: string) {
@@ -162,6 +170,10 @@ export function registerControllers(baseUrl: string = '', router: Router = Route
 
             if (route.method === RouteMethod.Head && returnType !== Boolean) {
                 throw new HeadHasWrongReturnTypeError();
+            }
+
+            if (params.some((p: Param) => p.paramType === ParamType.Body) && !bodyParserInstalled) {
+                console.warn(`The route ${routeUrl} of controller '${instance.constructor.name}' uses a @Body parameter, but there is no 'body-parser' package installed.`);
             }
 
             params.forEach(p => {


### PR DESCRIPTION
Fixes #38 
- Simply adds a warning for each route that uses a `@Body` parameter and no `body-parser` package (default of express) is found
