### PR TITLE
Feature/new error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Example code for simple middleware.
 - Example code for passportJS middleware.
 
+### Changed
+- Reworked the error-handler system. Errors are now bubbled until the default is hit.
+
+
 ## [0.5.0] - 2016-05-09
 ### Added
 - Various example apps.

--- a/controllers/ControllerDecorator.ts
+++ b/controllers/ControllerDecorator.ts
@@ -6,7 +6,7 @@ import {
     DuplicateRouteDeclarationError,
     ParameterConstructorArgumentsError,
     WrongReturnTypeError,
-    RouteError,
+    GenericRouteError,
     RequiredParameterNotProvidedError,
     ParameterParseError,
     ParamValidationFailedError,
@@ -236,12 +236,12 @@ export function registerControllers(baseUrl: string = '', router: Router = Route
                         return response.status((result) ? httpStatus.OK : httpStatus.NOT_FOUND).end();
                     }
                     if (returnType === Promise) {
-                        (result as Promise<any>).then(responseFunction, err => errorHandlers.callHandlers(instance, request, response, new RouteError(route.propertyKey, err)));
+                        (result as Promise<any>).then(responseFunction, err => errorHandlers.callHandlers(instance, request, response, new GenericRouteError(route.propertyKey, err)));
                     } else {
                         responseFunction(result);
                     }
                 } catch (e) {
-                    errorHandlers.callHandlers(instance, request, response, new RouteError(route.propertyKey, e));
+                    errorHandlers.callHandlers(instance, request, response, new GenericRouteError(route.propertyKey, e));
                 }
             };
 

--- a/controllers/ControllerDecorator.ts
+++ b/controllers/ControllerDecorator.ts
@@ -13,9 +13,10 @@ import {
     HeadHasWrongReturnTypeError
 } from '../errors/Errors';
 import {Param, PARAMS_KEY, ParamType} from '../params/ParamDecorators';
-import {ErrorHandlerManager, ERRORHANDLER_KEY, DEFAULT_ERROR_HANDLER} from '../errors/ErrorHandlerDecorator';
+import {ERRORHANDLER_KEY} from '../errors/ErrorHandlerDecorator';
 import {Validator} from '../validators/Validators';
 import {RequestHandler} from 'express-serve-static-core';
+import {ControllerErrorHandler} from '../errors/ControllerErrorHandler';
 import httpStatus = require('http-status');
 
 let controllers: ControllerRegistration[] = [],
@@ -197,18 +198,24 @@ export function registerControllers(baseUrl: string = '', router: Router = Route
             params = params.sort((p1, p2) => (p1.index < p2.index) ? -1 : 1);
 
             route.descriptor.value = (request: Request, response: Response, next) => {
-                let errorHandlers: ErrorHandlerManager = Reflect.getMetadata(ERRORHANDLER_KEY, ctrlTarget),
+                let errorHandler: ControllerErrorHandler = Reflect.getMetadata(ERRORHANDLER_KEY, ctrlTarget),
                     paramValues = [];
 
-                if (!errorHandlers) {
-                    errorHandlers = new ErrorHandlerManager();
-                    errorHandlers.addHandler(DEFAULT_ERROR_HANDLER);
+                if (!errorHandler) {
+                    errorHandler = new ControllerErrorHandler();
                 }
+
+                let handleError = (error: any) => {
+                    if (!(error instanceof Error)) {
+                        error = new GenericRouteError(route.propertyKey, error);
+                    }
+                    errorHandler.handleError(instance, request, response, error);
+                };
 
                 try {
                     paramValues = getParamValues(params, request, response);
                 } catch (e) {
-                    errorHandlers.callHandlers(instance, request, response, e);
+                    handleError(e);
                     // This return is needed, since the controller
                     // would try to call the route method (even on error).
                     return;
@@ -230,18 +237,18 @@ export function registerControllers(baseUrl: string = '', router: Router = Route
                         return response.status(httpStatus.NO_CONTENT).end();
                     }
                     if (!(result instanceof returnType) && !(result.constructor === returnType)) {
-                        throw new WrongReturnTypeError(route.propertyKey, returnType, result.constructor);
+                        handleError(new WrongReturnTypeError(route.propertyKey, returnType, result.constructor));
                     }
                     if (route.method === RouteMethod.Head && returnType === Boolean) {
                         return response.status((result) ? httpStatus.OK : httpStatus.NOT_FOUND).end();
                     }
                     if (returnType === Promise) {
-                        (result as Promise<any>).then(responseFunction, err => errorHandlers.callHandlers(instance, request, response, new GenericRouteError(route.propertyKey, err)));
+                        (result as Promise<any>).then(responseFunction, handleError);
                     } else {
                         responseFunction(result);
                     }
                 } catch (e) {
-                    errorHandlers.callHandlers(instance, request, response, new GenericRouteError(route.propertyKey, e));
+                    handleError(e);
                 }
             };
 

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -122,6 +122,6 @@ does not even provide the parameter, `badReq` will be called instead of `errorHa
 
 *Note*: They won't be called both! Only the helpers for a given type are called. If no
 helpers are found for an error type, the handler will bubble up the chain until 
-he hits the default.
+it hits the default.
 
 You cannot register multiple handlers on one error type.

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -58,7 +58,7 @@ and handle the runtime errors. But more on that later, first a brief list of run
 ## Error handling
 
 As long as some runtime errors happen, you can do something with them. It's possible
-to register multiple `@ErrorHandler` for a controller - altough the are replaced. 
+to register multiple `@ErrorHandler` for a controller - although they are replaced.
 Those are called when an error happens during the execution of the 
 method or the parameter parsing process. You can register an
 `@ErrorHandler` for a specific (or multiple specific) error classes and even register your

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -33,7 +33,7 @@ The runtime errors happen during the usage of your api. They will *_not_* crash 
 If your controller has no `@ErrorHandler` registered, the following default is used:
 
 ```typescript
-const defaultErrorHandler = (req, res, err) => {
+const DEFAULT_ERROR_HANDLER = (req, res, err) => {
     console.error(err);
     res.status(httpStatus.INTERNAL_SERVER_ERROR).end();
 };
@@ -58,10 +58,13 @@ and handle the runtime errors. But more on that later, first a brief list of run
 ## Error handling
 
 As long as some runtime errors happen, you can do something with them. It's possible
-to register multiple `@ErrorHandler` for a controller. Those are called when an error happens
-during the execution of the method or the parameter parsing process. You can register an
+to register multiple `@ErrorHandler` for a controller - altough the are replaced. 
+Those are called when an error happens during the execution of the 
+method or the parameter parsing process. You can register an
 `@ErrorHandler` for a specific (or multiple specific) error classes and even register your
-own errors.
+own errors. The most specific errorhandler will be called. If no errorhandler for the given
+error is registered, the handler will "bubble" up the prototype chain of your thrown error and
+will call the default if nothing is registered.
 
 `TestController.ts`:
 
@@ -105,7 +108,7 @@ export class TestController {
     }
     
      @ErrorHandler(RequiredParameterNotProvidedError, ParameterParseError)
-    public badReq(request: Request, response: Response, error: Error): void {
+    public badReq(request: Request, response: Response, error: RequiredParameterNotProvidedError|ParameterParseError): void {
         console.log('This is a bad request from the client.');
         response.status(400).end();
     }
@@ -113,12 +116,12 @@ export class TestController {
 ```
 
 In the example above, if `mongoDb` throws an error or something bad happens there,
-the `errorHandler` function is called because the error will be wrapped in a `RouteError`.
+the `errorHandler` function is called because the error is not specially registered.
 But when the client delivers a string as the query parameter "size", or if the client
 does not even provide the parameter, `badReq` will be called instead of `errorHandler`.
 
 *Note*: They won't be called both! Only the helpers for a given type are called. If no
-helpers are found for an error type, the default is called.
+helpers are found for an error type, the handler will bubble up the chain until 
+he hits the default.
 
-You can register multiple error handlers for the same or default errors, but you need to
-keep in mind that you only send the express headers once.
+You cannot register multiple handlers on one error type.

--- a/errors/ControllerErrorHandler.spec.ts
+++ b/errors/ControllerErrorHandler.spec.ts
@@ -1,0 +1,81 @@
+import chai = require('chai');
+import sinon = require('sinon');
+import sinonChai = require('sinon-chai');
+import {ErrorHandlerWrongArgumentsError, RouteError} from './Errors';
+import {ControllerErrorHandler} from './ControllerErrorHandler';
+
+let should = chai.should();
+chai.use(sinonChai);
+
+describe('ControllerErrorHandler', () => {
+
+    let manager: ControllerErrorHandler;
+
+    beforeEach(() => {
+        manager = new ControllerErrorHandler();
+    });
+
+    it('should add a handler to default', () => {
+        let func = (req, res, err) => console.log(err);
+
+        manager.addHandler(func);
+
+        (manager as any).handlers.Error.should.equal(func);
+    });
+
+    it('should add a handler to a specific error', () => {
+        let func = (req, res, err) => console.log(err);
+
+        manager.addHandler(func, RouteError);
+
+        (manager as any).handlers.RouteError.should.equal(func);
+    });
+
+    it('should add a handler to multiple specific errors', () => {
+        let func = (req, res, err) => console.log(err);
+
+        manager.addHandler(func, RouteError);
+        manager.addHandler(func, ErrorHandlerWrongArgumentsError);
+
+        (manager as any).handlers.RouteError.should.equals(func);
+        (manager as any).handlers.ErrorHandlerWrongArgumentsError.should.equals(func);
+    });
+
+    it('should replace the handler if another is registered', () => {
+        let func = (req, res, err) => console.log(err);
+        let func2 = (req, res, err) => console.log(err);
+
+        manager.addHandler(func, RouteError);
+        manager.addHandler(func2, RouteError);
+
+        (manager as any).handlers.RouteError.should.equal(func2);
+    });
+
+    it('should call correct handler error', () => {
+        let spy = sinon.spy();
+
+        manager.addHandler(spy);
+        manager.addHandler(spy, ErrorHandlerWrongArgumentsError);
+
+        manager.handleError(null, null, null, new Error());
+
+        spy.should.be.calledOnce;
+    });
+
+    it('should call correct handler for a specific error', () => {
+        let spy = sinon.spy(),
+            spy2 = sinon.spy(),
+            spy3 = sinon.spy();
+
+        manager.addHandler(spy, ErrorHandlerWrongArgumentsError);
+        manager.addHandler(spy2, RouteError);
+        manager.addHandler(spy3);
+
+        manager.handleError(null, null, null, new ErrorHandlerWrongArgumentsError());
+
+        spy.should.be.calledOnce;
+        spy2.should.not.be.called;
+        spy3.should.not.be.called;
+    });
+
+});

--- a/errors/ControllerErrorHandler.spec.ts
+++ b/errors/ControllerErrorHandler.spec.ts
@@ -78,4 +78,14 @@ describe('ControllerErrorHandler', () => {
         spy3.should.not.be.called;
     });
 
+    it('should call the default if a non error type is thrown in', () => {
+        let spy = sinon.spy();
+
+        manager.addHandler(spy);
+
+        manager.handleError(null, null, null, 'foobar' as any);
+
+        spy.should.be.called;
+    });
+
 });

--- a/errors/ControllerErrorHandler.ts
+++ b/errors/ControllerErrorHandler.ts
@@ -55,6 +55,10 @@ export class ControllerErrorHandler {
      * @param {Error} error - Error object that was thrown.
      */
     public handleError<T extends Error>(context: any, request: Request, response: Response, error: T): void {
+        if (!(error instanceof Error)) {
+            error = new Error(error as any) as T;
+        }
+
         let proto = Object.getPrototypeOf(error);
         while (proto) {
             let type = proto.constructor;

--- a/errors/ControllerErrorHandler.ts
+++ b/errors/ControllerErrorHandler.ts
@@ -44,9 +44,8 @@ export class ControllerErrorHandler {
         let type = ((errorType || Error) as any).name;
 
         if (this.handlers[type]) {
-            let oldHandler: any = this.handlers[type],
-                newHandler: any = handler;
-            console.warn(`Duplicate error handler declaration for type '${type}'.\nActual handler: ${oldHandler.name}\nNew handler: ${newHandler.name}`);
+            let oldHandler: any = this.handlers[type];
+            console.warn(`Duplicate error handler declaration for type '${type}'.\nActual handler: ${oldHandler.name}\nNew handler: ${(handler as any).name}`);
         }
 
         this.handlers[type] = handler;

--- a/errors/ControllerErrorHandler.ts
+++ b/errors/ControllerErrorHandler.ts
@@ -1,0 +1,68 @@
+import 'reflect-metadata';
+import {Request, Response} from 'express';
+import httpStatus = require('http-status');
+
+/**
+ * Default error handler. Does console.error with the error and sets the
+ * http response code to 500.
+ *
+ * @param {Request} req - express request object
+ * @param {Response} res - express response object
+ * @param {Error} err - error that happend
+ */
+export const DEFAULT_ERROR_HANDLER = (req, res, err) => {
+    console.error(err);
+    res.status(httpStatus.INTERNAL_SERVER_ERROR).end();
+};
+
+/**
+ * @typedef ErrorHandlerFunction
+ * @type {Function}
+ * @param {Request} request - ExpressJS request object.
+ * @param {Response} response - ExpressJS response object.
+ * @param {Error} error - The error that happend.
+ */
+export type ErrorHandlerFunction<T extends Error> = (request: Request, response: Response, error: T) => void;
+
+/**
+ * Manager object that handles all ErrorHandlerFunctions for a controller. Registers itself in the controllers
+ * metadata. If an error is thrown, just pass it to the error handler. The handler will do all the magic.
+ *
+ * @class
+ */
+export class ControllerErrorHandler {
+    private handlers: { [id: string]: ErrorHandlerFunction<Error> } = {'Error': DEFAULT_ERROR_HANDLER};
+
+    /**
+     * Adds an error handler for the current controller with the given errorType. If the errorType is omitted,
+     * the handler registers the function as a 'default' error handler.
+     *
+     * @param {ErrorHandlerFunction} handler - The error handler to register.
+     * @param {Error} [errorType] - Error class that should be registered. If omitted, the handler is registered as default.
+     */
+    public addHandler<T extends Error>(handler: ErrorHandlerFunction<T>, errorType?: Function): void {
+        let type = ((errorType || Error) as any).name;
+
+        this.handlers[type] = handler;
+    }
+
+    /**
+     * Calls the error handler for a given error.
+     *
+     * @param {any} context - Context of the error handler.
+     * @param {Request} request - ExpressJS request object.
+     * @param {Response} response - ExpressJS response object.
+     * @param {Error} error - Error object that was thrown.
+     */
+    public handleError<T extends Error>(context: any, request: Request, response: Response, error: T): void {
+        let proto = Object.getPrototypeOf(error);
+        while (proto) {
+            let type = proto.constructor;
+            if (this.handlers[type.name]) {
+                this.handlers[type.name].apply(context, [request, response, error]);
+                break;
+            }
+            proto = Object.getPrototypeOf(proto);
+        }
+    }
+}

--- a/errors/ControllerErrorHandler.ts
+++ b/errors/ControllerErrorHandler.ts
@@ -43,6 +43,12 @@ export class ControllerErrorHandler {
     public addHandler<T extends Error>(handler: ErrorHandlerFunction<T>, errorType?: Function): void {
         let type = ((errorType || Error) as any).name;
 
+        if (this.handlers[type]) {
+            let oldHandler: any = this.handlers[type],
+                newHandler: any = handler;
+            console.warn(`Duplicate error handler declaration for type '${type}'.\nActual handler: ${oldHandler.name}\nNew handler: ${newHandler.name}`);
+        }
+
         this.handlers[type] = handler;
     }
 

--- a/errors/ErrorHandlerDecorator.spec.ts
+++ b/errors/ErrorHandlerDecorator.spec.ts
@@ -1,7 +1,7 @@
 import chai = require('chai');
 import sinon = require('sinon');
 import sinonChai = require('sinon-chai');
-import {ErrorHandlerManager, ErrorHandler, ERRORHANDLER_KEY} from './ErrorHandlerDecorator';
+import {ErrorHandler, ERRORHANDLER_KEY} from './ErrorHandlerDecorator';
 import {
     ErrorHandlerWrongArgumentsError,
     ErrorHandlerWrongArgumentTypesError,
@@ -39,202 +39,114 @@ class TestRouter {
 
 describe('ErrorHandlerDecorators', () => {
 
-    describe('ErrorHandlerManager', () => {
+    it('should throw on wrong handler argument count', () => {
+        let fn = () => {
+            class Ctrl {
+                @ErrorHandler()
+                public func(): void {
+                }
+            }
+        };
 
-        let manager: ErrorHandlerManager;
-
-        beforeEach(() => {
-            manager = new ErrorHandlerManager();
-        });
-
-        it('should add a handler to default', () => {
-            let func = (req, res, err) => console.log(err);
-
-            manager.addHandler(func);
-
-            (manager as any).handlers.default.should.be.an('array').with.lengthOf(1);
-        });
-
-        it('should add a handler to a specific error', () => {
-            let func = (req, res, err) => console.log(err);
-
-            manager.addHandler(func, Error);
-
-            (manager as any).handlers.default.should.be.an('array').with.lengthOf(0);
-            (manager as any).handlers.Error.should.be.an('array').with.lengthOf(1);
-        });
-
-        it('should add a handler to multiple specific errors', () => {
-            let func = (req, res, err) => console.log(err);
-
-            manager.addHandler(func, Error);
-            manager.addHandler(func, ErrorHandlerWrongArgumentsError);
-
-            (manager as any).handlers.default.should.be.an('array').with.lengthOf(0);
-            (manager as any).handlers.Error.should.be.an('array').with.lengthOf(1);
-            (manager as any).handlers.ErrorHandlerWrongArgumentsError.should.be.an('array').with.lengthOf(1);
-        });
-
-        it('should get correct handlers for default errors', () => {
-            let func = (req, res, err) => console.log(err);
-
-            manager.addHandler(func);
-
-            manager.getHandlers(new Error()).should.be.an('array').that.deep.equals([func]);
-        });
-
-        it('should get correct handlers for a specific error', () => {
-            let func = (req, res, err) => console.log(err);
-
-            manager.addHandler(func, ErrorHandlerWrongArgumentsError);
-
-            manager.getHandlers(new ErrorHandlerWrongArgumentsError()).should.be.an('array').that.deep.equals([func]);
-        });
-
-        it('should call correct handlers for default errors', () => {
-            let spy = sinon.spy(),
-                spy2 = sinon.spy();
-
-            manager.addHandler(spy);
-            manager.addHandler(spy2);
-
-            manager.callHandlers(null, null, null, new Error());
-
-            spy.should.be.calledOnce;
-            spy2.should.be.calledOnce;
-        });
-
-        it('should call correct handlers for a specific error', () => {
-            let spy = sinon.spy(),
-                spy2 = sinon.spy(),
-                spy3 = sinon.spy();
-
-            manager.addHandler(spy, ErrorHandlerWrongArgumentsError);
-            manager.addHandler(spy2, ErrorHandlerWrongArgumentsError);
-            manager.addHandler(spy3);
-
-            manager.callHandlers(null, null, null, new ErrorHandlerWrongArgumentsError());
-
-            spy.should.be.calledOnce;
-            spy2.should.be.calledOnce;
-            spy3.should.not.be.called;
-        });
-
+        fn.should.throw(ErrorHandlerWrongArgumentsError);
     });
 
-    describe('ErrorHandler decorator', () => {
-
-        it('should throw on wrong handler argument count', () => {
-            let fn = () => {
-                class Ctrl {
-                    @ErrorHandler()
-                    public func(): void {
-                    }
-                }
-            };
-
-            fn.should.throw(ErrorHandlerWrongArgumentsError);
-        });
-
-        it('should throw on wrong handler argument types', () => {
-            let fn = () => {
-                class Ctrl {
-                    @ErrorHandler()
-                    public func(req: any, res: string, err: number): void {
-                    }
-                }
-            };
-
-            fn.should.throw(ErrorHandlerWrongArgumentTypesError);
-        });
-
-        it('should throw on wrong handler return type', () => {
-            let fn = () => {
-                class Ctrl {
-                    @ErrorHandler()
-                    public func(req: Object, res: Object, err: Error): number {
-                        return 0;
-                    }
-                }
-            };
-
-            fn.should.throw(ErrorHandlerWrongReturnTypeError);
-        });
-
-        it('should register a handler for the controller', () => {
+    it('should throw on wrong handler argument types', () => {
+        let fn = () => {
             class Ctrl {
                 @ErrorHandler()
-                public func(req: Object, res: Object, err: Error): void {
+                public func(req: any, res: string, err: number): void {
                 }
             }
+        };
 
-            let errorManager: any = Reflect.getMetadata(ERRORHANDLER_KEY, Ctrl);
+        fn.should.throw(ErrorHandlerWrongArgumentTypesError);
+    });
 
-            errorManager.handlers.default
-                .should.be.an('array')
-                .with.lengthOf(1)
-                .that.deep.equals([Ctrl.prototype.func]);
-        });
-
-        it('should register a default and a specific handler for the controller', () => {
+    it('should throw on wrong handler return type', () => {
+        let fn = () => {
             class Ctrl {
                 @ErrorHandler()
-                public func(req: Object, res: Object, err: Error): void {
-                }
-
-                @ErrorHandler(ErrorHandlerWrongReturnTypeError, ErrorHandlerWrongArgumentsError)
-                public func2(req: Object, res: Object, err: Error): void {
+                public func(req: Object, res: Object, err: Error): number {
+                    return 0;
                 }
             }
+        };
 
-            let errorManager: any = Reflect.getMetadata(ERRORHANDLER_KEY, Ctrl);
+        fn.should.throw(ErrorHandlerWrongReturnTypeError);
+    });
 
-            errorManager.handlers.default
-                .should.be.an('array')
-                .with.lengthOf(1)
-                .that.deep.equals([Ctrl.prototype.func]);
+    it('should register a handler for the controller', () => {
+        class Ctrl {
+            @ErrorHandler()
+            public func(req: Object, res: Object, err: Error): void {
+            }
+        }
 
-            errorManager.handlers.ErrorHandlerWrongReturnTypeError
-                .should.be.an('array')
-                .with.lengthOf(1)
-                .that.deep.equals([Ctrl.prototype.func2]);
+        let errorManager: any = Reflect.getMetadata(ERRORHANDLER_KEY, Ctrl);
 
-            errorManager.handlers.ErrorHandlerWrongArgumentsError
-                .should.be.an('array')
-                .with.lengthOf(1)
-                .that.deep.equals([Ctrl.prototype.func2]);
-        });
+        errorManager.handlers.Error
+            .should.be.a('function')
+            .with.lengthOf(3)
+            .that.deep.equals(Ctrl.prototype.func);
+    });
 
-        it('should set the correct this context', () => {
-            @Controller()
-            class Ctrl {
-                private test = 'foobar';
-
-                @Route()
-                public func() {
-                    throw 'Foobar';
-                }
-
-                @ErrorHandler()
-                public error(req: Object, res: Object, err: Error): void {
-                    this.should.be.an.instanceOf(Ctrl);
-                    this.test.should.equal('foobar');
-                }
+    it('should register a default and a specific handler for the controller', () => {
+        class Ctrl {
+            @ErrorHandler()
+            public func(req: Object, res: Object, err: Error): void {
             }
 
-            let router = new TestRouter();
+            @ErrorHandler(ErrorHandlerWrongReturnTypeError, ErrorHandlerWrongArgumentsError)
+            public func2(req: Object, res: Object, err: Error): void {
+            }
+        }
 
-            registerControllers('', (router as any));
+        let errorManager: any = Reflect.getMetadata(ERRORHANDLER_KEY, Ctrl);
 
-            router.routes['/'].apply(this, [{}, {
-                json: () => {
-                },
-                send: () => {
-                }
-            }, null]);
-        });
+        errorManager.handlers.Error
+            .should.be.a('function')
+            .with.lengthOf(3)
+            .that.deep.equals(Ctrl.prototype.func);
 
+        errorManager.handlers.ErrorHandlerWrongReturnTypeError
+            .should.be.a('function')
+            .with.lengthOf(3)
+            .that.deep.equals(Ctrl.prototype.func2);
 
+        errorManager.handlers.ErrorHandlerWrongArgumentsError
+            .should.be.a('function')
+            .with.lengthOf(3)
+            .that.deep.equals(Ctrl.prototype.func2);
+    });
+
+    it('should set the correct this context', () => {
+        @Controller()
+        class Ctrl {
+            private test = 'foobar';
+
+            @Route()
+            public func() {
+                throw 'Foobar.';
+            }
+
+            @ErrorHandler()
+            public error(req: Object, res: Object, err: Error): void {
+                this.should.be.an.instanceOf(Ctrl);
+                this.test.should.equal('foobar');
+            }
+        }
+
+        let router = new TestRouter();
+
+        registerControllers('', (router as any));
+
+        router.routes['/'].apply(this, [{}, {
+            json: () => {
+            },
+            send: () => {
+            }
+        }, null]);
     });
 
 });

--- a/errors/Errors.ts
+++ b/errors/Errors.ts
@@ -1,5 +1,37 @@
 import {RouteMethod} from '../routes/RouteDecorators';
 
+/// Error bases
+
+export class DesigntimeError extends Error {
+    constructor() {
+        super();
+    }
+}
+
+export class RuntimeError extends Error {
+    constructor() {
+        super();
+    }
+}
+
+export class ParameterError extends RuntimeError {
+    constructor() {
+        super();
+    }
+}
+
+export class RouteError extends RuntimeError {
+    constructor() {
+        super();
+    }
+}
+
+export class ValidationError extends ParameterError {
+    constructor() {
+        super();
+    }
+}
+
 /// Registration & Controller errors
 
 /**
@@ -8,7 +40,7 @@ import {RouteMethod} from '../routes/RouteDecorators';
  *
  * @class
  */
-export class HttpVerbNotSupportedError extends Error {
+export class HttpVerbNotSupportedError extends DesigntimeError {
     constructor(method: RouteMethod) {
         super();
         this.message = `HttpVerb not supported; ${method}`;
@@ -21,7 +53,7 @@ export class HttpVerbNotSupportedError extends Error {
  *
  * @class
  */
-export class DuplicateRouteDeclarationError extends Error {
+export class DuplicateRouteDeclarationError extends DesigntimeError {
     constructor(url: string, method: RouteMethod) {
         super();
         this.message = `The route to url "${url}" with http method "${RouteMethod[method]}" is declared twice.`;
@@ -34,7 +66,7 @@ export class DuplicateRouteDeclarationError extends Error {
  *
  * @class
  */
-export class HeadHasWrongReturnTypeError extends Error {
+export class HeadHasWrongReturnTypeError extends DesigntimeError {
     constructor() {
         super();
         this.message = 'Head route must have return type boolean';
@@ -47,7 +79,7 @@ export class HeadHasWrongReturnTypeError extends Error {
  *
  * @class
  */
-export class ErrorHandlerWrongArgumentsError extends Error {
+export class ErrorHandlerWrongArgumentsError extends DesigntimeError {
     constructor() {
         super();
         this.message = 'Error handler must accept exactly request, response and an error object';
@@ -60,7 +92,7 @@ export class ErrorHandlerWrongArgumentsError extends Error {
  *
  * @class
  */
-export class ErrorHandlerWrongArgumentTypesError extends Error {
+export class ErrorHandlerWrongArgumentTypesError extends DesigntimeError {
     constructor() {
         super();
         this.message = 'Error handler arguments must be: Object, Object, Error';
@@ -73,7 +105,7 @@ export class ErrorHandlerWrongArgumentTypesError extends Error {
  *
  * @class
  */
-export class ErrorHandlerWrongReturnTypeError extends Error {
+export class ErrorHandlerWrongReturnTypeError extends DesigntimeError {
     constructor() {
         super();
         this.message = 'Error handler must have return type void';
@@ -88,7 +120,7 @@ export class ErrorHandlerWrongReturnTypeError extends Error {
  *
  * @class
  */
-export class ParameterConstructorArgumentsError extends Error {
+export class ParameterConstructorArgumentsError extends DesigntimeError {
     constructor(name: string) {
         super();
         this.message = `The constructor for the parameter "${name}" must accept at least 1 argument`;
@@ -101,7 +133,7 @@ export class ParameterConstructorArgumentsError extends Error {
  *
  * @class
  */
-export class RequiredParameterNotProvidedError extends Error {
+export class RequiredParameterNotProvidedError extends ParameterError {
     constructor(name: string) {
         super();
         this.message = `The required parameter "${name}" was not provided`;
@@ -114,7 +146,7 @@ export class RequiredParameterNotProvidedError extends Error {
  *
  * @class
  */
-export class ParameterParseError extends Error {
+export class ParameterParseError extends ParameterError {
     constructor(name: string, public innerException: Error) {
         super();
         this.message = `Parsing of the parameter "${name}" threw an error.\nInnerException: ${innerException}`;
@@ -129,7 +161,7 @@ export class ParameterParseError extends Error {
  *
  * @class
  */
-export class WrongReturnTypeError extends Error {
+export class WrongReturnTypeError extends RouteError {
     constructor(name: string, expected: Function, received: Function) {
         super();
         this.message = `The method "${name}" returned the wrong result type.\nExpected: ${expected}\nReceived: ${received}`;
@@ -142,7 +174,7 @@ export class WrongReturnTypeError extends Error {
  *
  * @class
  */
-export class RouteError extends Error {
+export class GenericRouteError extends RouteError {
     constructor(name: string, public innerException: Error) {
         super();
         this.message = `The method "${name}" threw an error.\nInnerException: ${innerException}`;
@@ -157,7 +189,7 @@ export class RouteError extends Error {
  *
  * @class
  */
-export class ParamValidationFailedError extends Error {
+export class ParamValidationFailedError extends ValidationError {
     constructor(name: string) {
         super();
         this.message = `The validator for the parameter "${name}" was not valid.`;

--- a/errors/Errors.ts
+++ b/errors/Errors.ts
@@ -1,11 +1,5 @@
 import {RouteMethod} from '../routes/RouteDecorators';
 
-let format = (text: string, ...args: any[]) => {
-    return text.replace(/{(\d+)}/g, (match, number) => {
-        return typeof args[number] !== 'undefined' ? args[number] : match;
-    });
-};
-
 /// Registration & Controller errors
 
 /**
@@ -17,7 +11,7 @@ let format = (text: string, ...args: any[]) => {
 export class HttpVerbNotSupportedError extends Error {
     constructor(method: RouteMethod) {
         super();
-        this.message = format('HttpVerb not supported; {0}', method);
+        this.message = `HttpVerb not supported; ${method}`;
     }
 }
 
@@ -30,7 +24,7 @@ export class HttpVerbNotSupportedError extends Error {
 export class DuplicateRouteDeclarationError extends Error {
     constructor(url: string, method: RouteMethod) {
         super();
-        this.message = format('The route to url "{0}" with http method "{1}" is declared twice.', url, RouteMethod[method]);
+        this.message = `The route to url "${url}" with http method "${RouteMethod[method]}" is declared twice.`;
     }
 }
 
@@ -97,7 +91,7 @@ export class ErrorHandlerWrongReturnTypeError extends Error {
 export class ParameterConstructorArgumentsError extends Error {
     constructor(name: string) {
         super();
-        this.message = format('The constructor for the parameter "{0}" must accept at least 1 argument', name);
+        this.message = `The constructor for the parameter "${name}" must accept at least 1 argument`;
     }
 }
 
@@ -110,7 +104,7 @@ export class ParameterConstructorArgumentsError extends Error {
 export class RequiredParameterNotProvidedError extends Error {
     constructor(name: string) {
         super();
-        this.message = format('The required parameter "{0}" was not provided', name);
+        this.message = `The required parameter "${name}" was not provided`;
     }
 }
 
@@ -123,7 +117,7 @@ export class RequiredParameterNotProvidedError extends Error {
 export class ParameterParseError extends Error {
     constructor(name: string, public innerException: Error) {
         super();
-        this.message = format('Parsing of the parameter "{0}" threw an error\nInnerException: {1}', name, innerException);
+        this.message = `Parsing of the parameter "${name}" threw an error.\nInnerException: ${innerException}`;
     }
 }
 
@@ -138,7 +132,7 @@ export class ParameterParseError extends Error {
 export class WrongReturnTypeError extends Error {
     constructor(name: string, expected: Function, received: Function) {
         super();
-        this.message = format('The method "{0}" returned the wrong result type.\nExpected: {1}\nReceived: {2}', name, expected, received);
+        this.message = `The method "${name}" returned the wrong result type.\nExpected: ${expected}\nReceived: ${received}`;
     }
 }
 
@@ -151,7 +145,7 @@ export class WrongReturnTypeError extends Error {
 export class RouteError extends Error {
     constructor(name: string, public innerException: Error) {
         super();
-        this.message = format('The method "{0}" threw an error.\nInnerException: {1}', name, innerException);
+        this.message = `The method "${name}" threw an error.\nInnerException: ${innerException}`;
     }
 }
 
@@ -166,6 +160,6 @@ export class RouteError extends Error {
 export class ParamValidationFailedError extends Error {
     constructor(name: string) {
         super();
-        this.message = format('The validator for the parameter "{0}" was not valid.', name);
+        this.message = `The validator for the parameter "${name}" was not valid.`;
     }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export * from './controllers/ControllerDecorator';
 export * from './errors/ErrorHandlerDecorator';
+export * from './errors/ControllerErrorHandler';
 export * from './errors/Errors';
 export * from './params/ParamDecorators';
 export * from './routes/RouteDecorators';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "istanbul cover -x \"**/*.spec.*\" _mocha -- --ui bdd --recursive ./build",
     "precitest": "npm run bootstrap && npm run clean && tsc",
     "citest": "istanbul cover -x \"**/*.spec.*\" _mocha --report lcovonly -- --ui bdd --recursive ./build",
-    "develop": "npm run clean && tsc --sourceMap -w"
+    "develop": "npm run clean && tsc --sourceMap -w --pretty"
   },
   "repository": {
     "type": "git",

--- a/params/ParamDecorators.spec.ts
+++ b/params/ParamDecorators.spec.ts
@@ -3,8 +3,9 @@ import {Query, PARAMS_KEY, Param, ParamType, UrlParam, Body, Req, Res, Header} f
 import {Route} from '../routes/RouteDecorators';
 import {Controller, registerControllers, resetControllerRegistrations} from '../controllers/ControllerDecorator';
 import {RequiredParameterNotProvidedError, ParameterParseError, ParamValidationFailedError} from '../errors/Errors';
-import {ErrorHandlerManager, ERRORHANDLER_KEY} from '../errors/ErrorHandlerDecorator';
+import {ERRORHANDLER_KEY} from '../errors/ErrorHandlerDecorator';
 import {isString, isNumber} from '../validators/Validators';
+import {ControllerErrorHandler} from '../errors/ControllerErrorHandler';
 import chai = require('chai');
 import sinon = require('sinon');
 import sinonChai = require('sinon-chai');
@@ -115,7 +116,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -168,7 +169,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -195,7 +196,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -223,7 +224,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -249,7 +250,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -276,7 +277,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -373,7 +374,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -470,7 +471,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -523,7 +524,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -550,7 +551,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -578,7 +579,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -604,7 +605,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -631,7 +632,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -839,7 +840,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -896,7 +897,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -930,7 +931,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -961,7 +962,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -993,7 +994,7 @@ describe('ParamDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);

--- a/routes/RouteDecorators.spec.ts
+++ b/routes/RouteDecorators.spec.ts
@@ -10,16 +10,12 @@ import {
     RouteRegistration,
     RouteMethod
 } from '../routes/RouteDecorators';
-import {
-    ParameterConstructorArgumentsError,
-    RouteError,
-    WrongReturnTypeError,
-    HeadHasWrongReturnTypeError
-} from '../errors/Errors';
+import {ParameterConstructorArgumentsError, WrongReturnTypeError, HeadHasWrongReturnTypeError} from '../errors/Errors';
 import {Query, Res} from '../params/ParamDecorators';
 import {Controller, registerControllers, resetControllerRegistrations} from '../controllers/ControllerDecorator';
 import {Response} from 'express';
-import {ErrorHandlerManager, ERRORHANDLER_KEY} from '../errors/ErrorHandlerDecorator';
+import {ERRORHANDLER_KEY} from '../errors/ErrorHandlerDecorator';
+import {ControllerErrorHandler} from '../errors/ControllerErrorHandler';
 import chai = require('chai');
 import sinon = require('sinon');
 import sinonChai = require('sinon-chai');
@@ -336,7 +332,7 @@ describe('RouteDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 spy = sinon.spy();
             handler.addHandler(spy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -353,8 +349,7 @@ describe('RouteDecorators', () => {
             }, null]);
 
             spy.should.be.calledOnce;
-            spy.args[0][2].should.be.an.instanceOf(RouteError);
-            spy.args[0][2].innerException.should.be.an.instanceOf(WrongReturnTypeError);
+            spy.args[0][2].should.be.an.instanceOf(WrongReturnTypeError);
         });
 
         it('should correctly execute a primitive promise when one is returned', done => {
@@ -366,7 +361,7 @@ describe('RouteDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 errSpy = sinon.spy();
             handler.addHandler(errSpy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -399,7 +394,7 @@ describe('RouteDecorators', () => {
                 }
             }
 
-            let handler = new ErrorHandlerManager(),
+            let handler = new ControllerErrorHandler(),
                 errSpy = sinon.spy();
             handler.addHandler(errSpy);
             Reflect.defineMetadata(ERRORHANDLER_KEY, handler, Ctrl);
@@ -418,8 +413,7 @@ describe('RouteDecorators', () => {
 
             setTimeout(() => {
                 errSpy.should.be.called;
-                errSpy.args[0][2].should.be.an.instanceOf(RouteError);
-                errSpy.args[0][2].innerException.should.be.an.instanceOf(Error);
+                errSpy.args[0][2].should.be.an.instanceOf(Error);
                 spy.should.not.be.called;
                 done();
             }, 100);


### PR DESCRIPTION
Closes #39 
- Errors get bubbled until `Error` is hit
- No multiple errorhandler per type allowed.
- A generalization of an error is possible
