### PR TITLE
Feature/alias for params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `@Controller` and all route decorators do optionally accept `RequestHandler` as middlewares.
 - Example code for simple middleware.
 - Example code for passportJS middleware.
+- Aliases for query parameters.
 
 ### Changed
 - Reworked the error-handler system. Errors are now bubbled until the default is hit.

--- a/controllers/ControllerDecorator.ts
+++ b/controllers/ControllerDecorator.ts
@@ -51,7 +51,7 @@ function extractParam(request: Request, param: Param): any {
                 return request.query[param.name];
             }
             let aliases = !Array.isArray(options.alias) ? [options.alias] : options.alias as string[];
-            aliases = aliases.map((a: string) => request.query[a]);
+            aliases = aliases.map((a: string) => request.query[a]).filter(Boolean);
             return aliases[0] || request.query[param.name];
         case ParamType.Header:
             return request.get(param.name);

--- a/controllers/ControllerDecorator.ts
+++ b/controllers/ControllerDecorator.ts
@@ -16,6 +16,7 @@ import {Param, PARAMS_KEY, ParamType} from '../params/ParamDecorators';
 import {ERRORHANDLER_KEY} from '../errors/ErrorHandlerDecorator';
 import {Validator} from '../validators/Validators';
 import {RequestHandler} from 'express-serve-static-core';
+import {QueryParamOptions} from '../params/ParamOptions';
 import {ControllerErrorHandler} from '../errors/ControllerErrorHandler';
 import httpStatus = require('http-status');
 
@@ -35,6 +36,25 @@ try {
 
 class ControllerRegistration {
     constructor(public controller: any, public prefix?: string, public middlewares: RequestHandler[] = []) {
+    }
+}
+
+function extractParam(request: Request, param: Param): any {
+    switch (param.paramType) {
+        case ParamType.Body:
+            return request.body;
+        case ParamType.Url:
+            return request.params[param.name];
+        case ParamType.Query:
+            let options: QueryParamOptions = param.options;
+            if (!options || !options.alias) {
+                return request.query[param.name];
+            }
+            let aliases = !Array.isArray(options.alias) ? [options.alias] : options.alias as string[];
+            aliases = aliases.map((a: string) => request.query[a]);
+            return aliases[0] || request.query[param.name];
+        case ParamType.Header:
+            return request.get(param.name);
     }
 }
 
@@ -88,17 +108,8 @@ function getParamValues(params: Param[], request: Request, response: Response) {
             case ParamType.Response:
                 paramValues[p.index] = response;
                 return;
-            case ParamType.Body:
-                paramValues[p.index] = parseParam(request.body, p);
-                return;
-            case ParamType.Url:
-                paramValues[p.index] = parseParam(request.params[p.name], p);
-                return;
-            case ParamType.Query:
-                paramValues[p.index] = parseParam(request.query[p.name], p);
-                return;
-            case ParamType.Header:
-                paramValues[p.index] = parseParam(request.get(p.name), p);
+            default:
+                paramValues[p.index] = parseParam(extractParam(request, p), p);
                 return;
         }
     });

--- a/docs/Parameters.md
+++ b/docs/Parameters.md
@@ -11,6 +11,34 @@ Most parameter decorators receive a `name` and an optional `options` argument.
 The name is used to identify the specific field in express and the options
 to define the behaviour of the param.
 
+## Options
+
+All parameters optionally accept an object for its configuration.
+The configuration options are described below.
+
+### General
+
+As a base for all parameter options there is the following interface:
+```typescript
+export interface ParamOptions {
+    required?: boolean;
+    validator?: Validator|Validator[];
+}
+```
+
+| Option    | Description                                                 |
+| --------- | ----------------------------------------------------------- |
+| required  | marks the parameter as required                             |
+| validator | one or multiple validators that all must evaluate to `true` |
+
+### Query
+
+For the query parameter decorator, there exists special options, which are specified below:
+
+| Option    | Description                                                                                                         |
+| --------- | ------------------------------------------------------------------------------------------------------------------- |
+| alias     | one or multiple alias(es) for the given query parameter.<br>If multiple aliases are hit, the first one is returned. |
+
 ## Decorators
 
 ### General

--- a/params/ParamDecorators.spec.ts
+++ b/params/ParamDecorators.spec.ts
@@ -87,6 +87,86 @@ describe('ParamDecorators', () => {
             }, null]);
         });
 
+        it('should inject the correct aliased variable', () => {
+            @Controller()
+            class Ctrl {
+                @Route()
+                public func(@Query('test', {alias: 't'}) test: string): any {
+                    test.should.equal('foobar');
+                    return {};
+                }
+            }
+
+            let router = new TestRouter();
+
+            registerControllers('', (router as any));
+
+            router.routes['/'].apply(this, [{query: {t: 'foobar'}}, {
+                json: () => {
+                }
+            }, null]);
+        });
+
+        it('should inject the correct multi aliased variable', () => {
+            @Controller()
+            class Ctrl {
+                @Route()
+                public func(@Query('test', {alias: ['t', 'te']}) test: string): any {
+                    test.should.equal('foobar');
+                    return {};
+                }
+            }
+
+            let router = new TestRouter();
+
+            registerControllers('', (router as any));
+
+            router.routes['/'].apply(this, [{query: {te: 'foobar'}}, {
+                json: () => {
+                }
+            }, null]);
+        });
+
+        it('should inject the correct variable if no alias hits', () => {
+            @Controller()
+            class Ctrl {
+                @Route()
+                public func(@Query('test', {alias: 't'}) test: string): any {
+                    test.should.equal('foobar');
+                    return {};
+                }
+            }
+
+            let router = new TestRouter();
+
+            registerControllers('', (router as any));
+
+            router.routes['/'].apply(this, [{query: {test: 'foobar'}}, {
+                json: () => {
+                }
+            }, null]);
+        });
+
+        it('should inject the correct aliased variable if alias and normal name is given', () => {
+            @Controller()
+            class Ctrl {
+                @Route()
+                public func(@Query('test', {alias: 't'}) test: string): any {
+                    test.should.equal('foobar');
+                    return {};
+                }
+            }
+
+            let router = new TestRouter();
+
+            registerControllers('', (router as any));
+
+            router.routes['/'].apply(this, [{query: {t: 'foobar', test: 'notFoobar!'}}, {
+                json: () => {
+                }
+            }, null]);
+        });
+
         it('should parse the correct value', () => {
             @Controller()
             class Ctrl {

--- a/params/ParamDecorators.ts
+++ b/params/ParamDecorators.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import {Validator} from '../validators/Validators';
+import {ParamOptions, QueryParamOptions} from './ParamOptions';
 
 /**
  * Reflect metadata key for parameter list.
@@ -17,21 +17,6 @@ export enum ParamType {
     Request,
     Response,
     Header
-}
-
-/**
- * Interface for parameter options. Contains optional settings for each parameter that accepts this interface.
- */
-export interface ParamOptions {
-    /**
-     * Defines if the parameter is set as required.
-     */
-    required?: boolean;
-
-    /**
-     * Adds one or more validator(s) to the parameter.
-     */
-    validator?: Validator|Validator[];
 }
 
 /**
@@ -59,10 +44,10 @@ function param(type: ParamType, name: string, options?: ParamOptions) {
  * Declares the current parameter as a query parameter. The route will provide this value from the request.query object.
  *
  * @param {string} name - the name of the parameter (inside the query object)
- * @param {ParamOptions} options - The specific options for this parameter.
+ * @param {QueryParamOptions} options - The specific options for this parameter.
  * @returns {(Object, string, number) => void} - Parameter decorator for the given function.
  */
-export function Query(name: string, options?: ParamOptions) {
+export function Query(name: string, options?: QueryParamOptions) {
     return param(ParamType.Query, name, options);
 }
 

--- a/params/ParamOptions.ts
+++ b/params/ParamOptions.ts
@@ -21,6 +21,7 @@ export interface ParamOptions {
 export interface QueryParamOptions extends ParamOptions {
     /**
      * One or multiple alias(es) for the query parameter (e.g. limit can be aliased with 'l').
+     * If multiple aliases are hit, the first one is returned.
      */
     alias?: string|string[];
 }

--- a/params/ParamOptions.ts
+++ b/params/ParamOptions.ts
@@ -1,0 +1,26 @@
+import {Validator} from '../validators/Validators';
+
+/**
+ * Interface for parameter options. Contains optional settings for each parameter that accepts this interface.
+ */
+export interface ParamOptions {
+    /**
+     * Defines if the parameter is set as required.
+     */
+    required?: boolean;
+
+    /**
+     * Adds one or more validator(s) to the parameter.
+     */
+    validator?: Validator|Validator[];
+}
+
+/**
+ * Interface for query parameter options. Contains basic parameter options and specific options for '@Query' parameters.
+ */
+export interface QueryParamOptions extends ParamOptions {
+    /**
+     * One or multiple alias(es) for the query parameter (e.g. limit can be aliased with 'l').
+     */
+    alias?: string|string[];
+}


### PR DESCRIPTION
Closes #49 
- Extends param options to accept aliases (for query params only)
- Adds tests for aliased query params
