### PR TITLE
Removed @types/inversify

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "@types/express": "^4.0.33",
     "@types/http-status": "^0.2.29",
-    "@types/inversify": "^2.0.31",
     "@types/node": "^6.0.45",
     "express": "^4.14.0",
     "filewalker": "^0.1.3",


### PR DESCRIPTION
Hi, 

I'm the author of InversifyJS thanks a lot for using it :smile: I hope that the library works well for you guys. Please share your feedback with us if you feel like the library is missing something. 

I have removed `@types/inversify` because the InversifyJS typings are included in its npm module.
