### PR TITLE
fix(route-generation): Correctly use controller route prefix for id generation

### DIFF
--- a/src/core/routes/GiuseppeBaseRoute.ts
+++ b/src/core/routes/GiuseppeBaseRoute.ts
@@ -22,13 +22,13 @@ export type FunctionMethodDecorator = (
  * Route decorator. Creates a route definition that reacts to a specified request. The method needs to be specified.
  * Can define one or multiple middlewares that are registered for that route. Also, a route name can be specified
  * that creates the url for express.
- * 
+ *
  * @export
  * @param {HttpMethod} method The http method to use.
  * @param {(string | RequestHandler)} [routeOrMiddleware] Either a string that represents the url for this route, or
  *                                                        an optional middleware if no specific route is needed.
  * @param {...RequestHandler[]} middlewares Other middlewares that are used for this route.
- * @returns {FunctionMethodDecorator} 
+ * @returns {FunctionMethodDecorator}
  */
 export function Route(
     method: HttpMethod,
@@ -50,7 +50,7 @@ export function Route(
 /**
  * Default core base route of giuseppe. Is configurable with all defined http methods of express (from the source).
  * Specifies it's http method via the enum {@link HttpMethod}.
- * 
+ *
  * @export
  * @class GiuseppeBaseRoute
  * @implements {RouteDefinition}
@@ -74,7 +74,7 @@ export class GiuseppeBaseRoute implements RouteDefinition {
     ): GiuseppeRoute[] {
         return [
             {
-                id: `${HttpMethod[this.httpMethod]}_${this.route}`,
+                id: `${HttpMethod[this.httpMethod]}_${baseUrl}_${this.route}`,
                 name: this.name,
                 method: this.httpMethod,
                 url: UrlHelper.buildUrl(baseUrl, this.route),

--- a/test/Giuseppe.spec.ts
+++ b/test/Giuseppe.spec.ts
@@ -385,6 +385,24 @@ describe('Giuseppe', () => {
                 expect(fn).toThrowErrorMatchingSnapshot();
             });
 
+            it('should not throw on a similar route in a different controller', () => {
+                @Controller('a')
+                class CtrlA {
+                    @Get('getFunc')
+                    public func(): void { }
+                }
+
+                @Controller('b')
+                class CtrlB {
+                    @Get('getFunc')
+                    public func(): void { }
+                }
+
+                const fn = () => giuseppe.configureRouter('baseUrl');
+
+                expect(fn).not.toThrow();
+            });
+
             it('should order the urls correctly (all cases)', () => {
                 @Controller()
                 class Ctrl {

--- a/test/__snapshots__/Giuseppe.spec.ts.snap
+++ b/test/__snapshots__/Giuseppe.spec.ts.snap
@@ -53,4 +53,4 @@ Array [
 ]
 `;
 
-exports[`Giuseppe Core configureRouter() should throw on a duplicate route 1`] = `"A route with the ID 'get_getFunc' (method name: 'func2', url: 'baseUrl/getFunc') is already registered."`;
+exports[`Giuseppe Core configureRouter() should throw on a duplicate route 1`] = `"A route with the ID 'get_baseUrl_getFunc' (method name: 'func2', url: 'baseUrl/getFunc') is already registered."`;

--- a/test/core/controller/CoreController.spec.ts
+++ b/test/core/controller/CoreController.spec.ts
@@ -106,7 +106,7 @@ describe('Core controller', () => {
 
             const ctrl = Giuseppe.registrar.controller[0];
             const route = ctrl.createRoutes('')[0];
-            expect(route.id).toBe('get_');
+            expect(route.id).toBe('get__');
             expect(route.name).toBe('get');
         });
 
@@ -127,15 +127,15 @@ describe('Core controller', () => {
             const routes = ctrl.createRoutes('');
 
             let route = routes[0];
-            expect(route.id).toBe('get_foobar');
+            expect(route.id).toBe('get_api_foobar');
             expect(route.url).toBe('api/foobar');
 
             route = routes[1];
-            expect(route.id).toBe('get_/barfoo');
+            expect(route.id).toBe('get_api_/barfoo');
             expect(route.url).toBe('api/barfoo');
 
             route = routes[2];
-            expect(route.id).toBe('get_/rootfoo');
+            expect(route.id).toBe('get_api_/rootfoo');
             expect(route.url).toBe('api/rootfoo');
         });
 

--- a/test/core/routes/CoreRoutes.spec.ts
+++ b/test/core/routes/CoreRoutes.spec.ts
@@ -211,7 +211,7 @@ describe('Core routes', () => {
                     const route = meta.routes()[0];
                     const generated = route.createRoutes(meta, '', [])[0];
 
-                    expect(generated.id).toBe(`${run.name}_TheUrl`);
+                    expect(generated.id).toBe(`${run.name}__TheUrl`);
                 });
 
                 it('should use the correct name', () => {


### PR DESCRIPTION
- Fixes #143 